### PR TITLE
Renderer improvements and better Whitespace handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Created by https://www.gitignore.io/api/node
 # Edit at https://www.gitignore.io/?templates=node
 
+### User ###
+_notes.md
+
 ### Typescript ###
 dist/
 dist.esm/

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ samples/
 node_modules/
 jasmine.json
 tsconfig*
+_notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add line numbers to tokens.
 - Allow any title field attributes.
 - Better title page parsing in general.
+- Fix line break logic in dialogue.
 
 ## [1.1.4] - 2023-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,28 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-- Improve rendering per spec like stripping sections and synopses since these should not be rendered.
-- Return more explicit null values and enable strict null checking.
 - Add line numbers to tokens.
 - Allow any title field attributes.
 - Better title page parsing in general.
+- Fix boneyard and notes parsing.
+- Work on options for perserving vertical space in Action per spec.
+
+## [1.2.0] - 2023-10-27
+
+### Added
+
+- Tabs and spaces retained in Action elements. Tabs are converted to four spaces.
+
+### Changed
+
+- Improve rendering per spec like stripping sections and synopses since these should not be rendered.
+- Return more explicit null values and enable strict null checking.
+- Better whitespace handling while lexing.
+
+### Fixed
+
 - Fix line break logic in dialogue.
-- Fix issue with empty strings returning `<p>undefined</p>`
-- Tabs and spaces retained in Action elements. Tabs are converted to four spaces
+- Fix issue with empty strings returning `<p>undefined</p>`.
 
 ## [1.1.4] - 2023-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Better title page parsing in general.
 - Fix line break logic in dialogue.
 - Fix issue with empty strings returning `<p>undefined</p>`
+- Tabs and spaces retained in Action elements. Tabs are converted to four spaces
 
 ## [1.1.4] - 2023-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Allow any title field attributes.
 - Better title page parsing in general.
 - Fix line break logic in dialogue.
+- Fix issue with empty strings returning `<p>undefined</p>`
 
 ## [1.1.4] - 2023-10-01
 

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Fountain-js is natively written in Typescript, therefore a `Script` interface is
 
 ```typescript
 interface Script {
-    title?: string,
+    title: string,
     html: {
         title_page: string,
         script: string
     },
-    tokens?: Token[]
+    tokens: Token[]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountain-js",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "A simple parser for Fountain, a markup language for formatting screenplays.",
   "main": "dist/index.js",
   "module": "dist.esm/index.js",

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -15,12 +15,12 @@ describe('Fountain Markup Parser', () => {
     it('should return tokens when true', () => {
         const action = "It was a cold and clear morning.";
 
-        let actual: Script = fountain.parse(action, true);
+        let actual = fountain.parse(action, true);
         let expected: Script = {
-            title: undefined,
+            title: '',
             html: {
                 title_page: '',
-                script: "<p>It was a cold and clear morning.</p>"
+                script: '<p>It was a cold and clear morning.</p>'
             },
             tokens: [
                 new ActionToken('It was a cold and clear morning.')
@@ -33,8 +33,8 @@ describe('Fountain Markup Parser', () => {
     it('should parse forced action', () => {
         const action = '!William enters -- and there stands Anna.';
 
-        let actual: Token[] = fountain.parse(action, true).tokens || [];
-        let expected: Token[] = [
+        let actual = fountain.parse(action, true).tokens;
+        let expected = [
             new ActionToken('William enters -- and there stands Anna.')
         ];
 
@@ -45,8 +45,8 @@ describe('Fountain Markup Parser', () => {
         const action = `!TIRES SCREECHING...
                     Joe is looking at his phone for the direction.`;
 
-        let actual: Token[] = fountain.parse(action, true).tokens || [];
-        let expected: Token[] = [
+        let actual = fountain.parse(action, true).tokens;
+        let expected = [
             new ActionToken('TIRES SCREECHING...\nJoe is looking at his phone for the direction.')
         ];
 
@@ -66,14 +66,14 @@ describe('Fountain Markup Parser', () => {
                             1588 Mission Dr.
                             Solvang, CA 93463`;
 
-        let actual: Script = fountain.parse(title_page);
+        let actual = fountain.parse(title_page);
         let expected: Script = {
             title: 'BRICK & STEEL FULL RETIRED',
             html: {
                 title_page: '<h1><span class="bold underline">BRICK &amp; STEEL</span><br /><span class="bold underline">FULL RETIRED</span></h1><p class="credit">Written by</p><p class="authors">Stu Maschwitz</p><p class="source">Story by KTM</p><p class="draft-date">1/27/2012</p><p class="contact">Next Level Productions<br />1588 Mission Dr.<br />Solvang, CA 93463</p>',
                 script: ''
             },
-            tokens: undefined
+            tokens: []
         };
 
         expect(actual).toEqual(expected);
@@ -82,16 +82,16 @@ describe('Fountain Markup Parser', () => {
     it('should parse a scene heading', () => {
         const sceneHeading = "EXT. BRICK'S PATIO - DAY";
 
-        let actual: Script = fountain.parse(sceneHeading);
-        let expected: Script = { 
-            title: undefined, 
+        let actual = fountain.parse(sceneHeading);
+        let expected: Script = {
+            title: '', 
             html: { 
                 title_page: '', 
                 script: "<h3>EXT. BRICK'S PATIO - DAY</h3>" 
             },
-            tokens: undefined  
+            tokens: []
         };
-        
+
         expect(actual).toEqual(expected);
     });
 
@@ -126,9 +126,9 @@ describe('Fountain Markup Parser', () => {
         const alphaHeading = 'I/E HOUSE - DAY #A#';
         const alphaNumHeading = 'INT/EXT. HOUSE - DAY - FLASHBACK (1944) #110.A#';
 
-        let numToken: Token[] = fountain.parse(numHeaindg, true).tokens || [];
-        let alphaToken: Token[] = fountain.parse(alphaHeading, true).tokens || [];
-        let alphaNumToken: Token[] = fountain.parse(alphaNumHeading, true).tokens || [];
+        let numToken = fountain.parse(numHeaindg, true).tokens;
+        let alphaToken = fountain.parse(alphaHeading, true).tokens;
+        let alphaNumToken = fountain.parse(alphaNumHeading, true).tokens;
 
         expect(numToken).toEqual([ new SceneHeadingToken('INT. HOUSE - DAY #1#') ]);
         expect(alphaToken).toEqual([ new SceneHeadingToken('I/E HOUSE - DAY #A#') ]);
@@ -144,8 +144,8 @@ describe('Fountain Markup Parser', () => {
     it('should parse forced, single-aplhanumeric scene headings', () => {
         const heading = '.1';
 
-        let actual: Token[] = fountain.parse(heading, true).tokens || [];
-        let expected: Token[] = [ new SceneHeadingToken('.1') ];
+        let actual = fountain.parse(heading, true).tokens;
+        let expected = [ new SceneHeadingToken('.1') ];
 
         expect(actual).toEqual(expected);
     });
@@ -153,8 +153,8 @@ describe('Fountain Markup Parser', () => {
     it('should treat a period only at start of a line as action', () => {
         const notHeading = '.  ';
 
-        let actual: Token[] = fountain.parse(notHeading, true).tokens || [];
-        let expected: Token[] = [ new ActionToken('.  ') ];
+        let actual= fountain.parse(notHeading, true).tokens;
+        let expected = [ new ActionToken('.  ') ];
 
         expect(actual).toEqual(expected);
     });
@@ -167,9 +167,7 @@ describe('Fountain Markup Parser', () => {
 
                     SMASH CUT TO:`;
 
-        let output: Script = fountain.parse(text);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(text).html.script;
         let expected = '<h3>OPENING TITLES</h3><p class="centered">BRICK &amp; STEEL<br />FULL RETIRED</p><h2>SMASH CUT TO:</h2>';
 
         expect(actual).toBe(expected);
@@ -178,9 +176,7 @@ describe('Fountain Markup Parser', () => {
     it('should parse forced transitions', () => {
         const transition = '> Burn to Pink.';
 
-        let output: Script = fountain.parse(transition);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(transition).html.script;
         let expected = '<h2>Burn to Pink.</h2>';
 
         expect(actual).toBe(expected);
@@ -190,10 +186,8 @@ describe('Fountain Markup Parser', () => {
         const text = `>     center line 1     <
                       >     center line 2     <`;
 
-        const expected = '<p class="centered">center line 1<br />center line 2</p>';
-
-        const output: Script = fountain.parse(text);
-        const actual = output.html.script;
+        let actual = fountain.parse(text).html.script;
+        let expected = '<p class="centered">center line 1<br />center line 2</p>';
 
         expect(actual).toBe(expected);
     });
@@ -206,9 +200,7 @@ describe('Fountain Markup Parser', () => {
                     (skeptical)
                     Are they cold?`;
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>STEEL (O.S.)</h4><p>Beer\'s ready!</p></div><div class="dialogue"><h4>BRICK</h4><p class="parenthetical">(skeptical)</p><p>Are they cold?</p></div>';
 
         expect(actual).toBe(expected);
@@ -225,10 +217,9 @@ describe('Fountain Markup Parser', () => {
                         MONKEY
                     Dude, I'm a monkey.`;
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = `<div class="dialogue"><h4>DEALER</h4><p>Ten.<br />Four.<br />Dealer gets a seven.<br />  <br />Hit or stand sir?</p></div><div class="dialogue"><h4>MONKEY</h4><p>Dude, I'm a monkey.</p></div>`;
+
         expect(actual).toBe(expected);
     });
 
@@ -236,9 +227,7 @@ describe('Fountain Markup Parser', () => {
         const dialog = `@McCLANE
                     Yippie ki-yay! I got my lower-case C back!`;
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>McCLANE</h4><p>Yippie ki-yay! I got my lower-case C back!</p></div>'
 
         expect(actual).toBe(expected);
@@ -251,9 +240,7 @@ describe('Fountain Markup Parser', () => {
                         BRICK ^
                         Screw retirement.`;
 
-        let output: Script = fountain.parse(dualDialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dualDialog).html.script;
         let expected = '<div class="dual-dialogue"><div class="dialogue left"><h4>STEEL</h4><p>Screw retirement.</p></div><div class="dialogue right"><h4>BRICK</h4><p>Screw retirement.</p></div></div>';
 
         expect(actual).toBe(expected);
@@ -266,9 +253,7 @@ describe('Fountain Markup Parser', () => {
                         HANS (on the radio)
                     What was it you said?`;
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>MOM (O. S.)</h4><p>Luke! Come down for supper!</p></div><div class="dialogue"><h4>HANS (on the radio)</h4><p>What was it you said?</p></div>';
 
         expect(actual).toBe(expected);
@@ -278,9 +263,7 @@ describe('Fountain Markup Parser', () => {
         const dialog = `A
                     Pieces were stolen from me.`
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>A</h4><p>Pieces were stolen from me.</p></div>';
 
         expect(actual).toBe(expected);
@@ -290,9 +273,7 @@ describe('Fountain Markup Parser', () => {
         const dialog = `    @B
                     They never gave mine back.`
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>B</h4><p>They never gave mine back.</p></div>';
 
         expect(actual).toBe(expected);
@@ -303,9 +284,7 @@ describe('Fountain Markup Parser', () => {
                     (standing)
                     Excuse me. How much did it cost?`
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>DISGRUNTLED CITIZEN #1</h4><p class="parenthetical">(standing)</p><p>Excuse me. How much did it cost?</p></div>';
 
         expect(actual).toBe(expected);
@@ -315,9 +294,7 @@ describe('Fountain Markup Parser', () => {
         const dialog = `11 (O.S.)
                     I'm the monster.`
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = "<p>11 (O.S.)<br />I'm the monster.</p>";
 
         expect(actual).toBe(expected);
@@ -327,9 +304,7 @@ describe('Fountain Markup Parser', () => {
         const dialog = `@11
                     I'm the monster.`
 
-        let output: Script = fountain.parse(dialog);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(dialog).html.script;
         let expected = '<div class="dialogue"><h4>11</h4><p>I\'m the monster.</p></div>';
 
         expect(actual).toBe(expected);
@@ -340,9 +315,7 @@ describe('Fountain Markup Parser', () => {
                     (**starting the engine**)
                     So much for retirement!`;
 
-        let output: Script = fountain.parse(emphasisInside);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(emphasisInside).html.script;
         let expected = '<div class="dialogue"><h4>STEEL</h4><p class="parenthetical">(<span class="bold">starting the engine</span>)</p><p>So much for retirement!</p></div>';
 
         expect(actual).toBe(expected);
@@ -353,9 +326,7 @@ describe('Fountain Markup Parser', () => {
                     *(ah, wonderful)*
                     Oh, you've been "crunching numbers."`;
 
-        let output: Script = fountain.parse(emphasisOutside);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(emphasisOutside).html.script;
         let expected = `<div class="dialogue"><h4>WALT</h4><p class="parenthetical"><span class="italic">(ah, wonderful)</span></p><p>Oh, you've been &quot;crunching numbers.&quot;</p></div>`;
 
         expect(actual).toBe(expected);
@@ -367,9 +338,7 @@ describe('Fountain Markup Parser', () => {
                         Oh my --
                         La~de~da!`;
 
-        let output: Script = fountain.parse(wrongEmphasis);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(wrongEmphasis).html.script;
         let expected = '<div class="dialogue"><h4>TREVA</h4><p><span class="italic underline">*(sing-song)</span><br />Oh my --<br />La~de~da!</p></div>';
 
         expect(actual).toBe(expected);
@@ -378,7 +347,7 @@ describe('Fountain Markup Parser', () => {
     it('should be resiliant against parenthetical oddities', () => {
         const hangingParenthetical = `BRICK
                                 (confused)`;
-        
+
         const tooManySpaces = `DAN
                         Then let's retire them.
                         (grinning maniacally)                 
@@ -405,9 +374,7 @@ describe('Fountain Markup Parser', () => {
                             ***_(ear-splitting noises)_***
                             I'm upset.`;
 
-        let output: Script = fountain.parse(extremeEmphasis);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(extremeEmphasis).html.script;
         let expected = `<div class="dialogue"><h4>TOPHER</h4><p class="parenthetical"><span class="italic">(griping)</span></p><p class="parenthetical"><span class="bold">(complaining)</span></p><p class="parenthetical"><span class="underline">(grousing)</span></p><p class="parenthetical"><span class="bold italic">(howling)</span></p><p class="parenthetical"><span class="italic underline">(screaming)</span></p><p class="parenthetical"><span class="bold underline">(clangorously)</span></p><p class="parenthetical"><span class="bold italic underline">(ear-splitting noises)</span></p><p>I'm upset.</p></div>`;
 
         expect(actual).toBe(expected);
@@ -419,9 +386,7 @@ describe('Fountain Markup Parser', () => {
                         ~Oh my --
                         ~La~de~da!`;
 
-        let output: Script = fountain.parse(singing);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(singing).html.script;
         let expected = '<div class="dialogue"><h4>TREVA</h4><p class="parenthetical">(sing-song)</p><p class="lyrics">Oh my --<br />La~de~da!</p></div>';
 
         expect(expected).toBe(actual);
@@ -430,9 +395,7 @@ describe('Fountain Markup Parser', () => {
     it('should parse notes', () => {
         const notes = '[[Add an additional beat here]]';
 
-        let output: Script = fountain.parse(notes);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(notes).html.script;
         let expected = '<!-- Add an additional beat here -->';
 
         expect(actual).toBe(expected);
@@ -442,9 +405,7 @@ describe('Fountain Markup Parser', () => {
         const lyrics = `~Willy Wonka! Willy Wonka! The amazing chocolatier!
                         ~Willy Wonka! Willy Wonka! Everybody give a cheer!`;
 
-        let output: Script = fountain.parse(lyrics);
-        let actual = output.html.script;
-
+        let actual = fountain.parse(lyrics).html.script;
         let expected = '<p class="lyrics">Willy Wonka! Willy Wonka! The amazing chocolatier!<br />Willy Wonka! Willy Wonka! Everybody give a cheer!</p>';
 
         expect(actual).toBe(expected);
@@ -479,8 +440,8 @@ describe('Fountain Markup Parser', () => {
     it('should parse synopses by removing them from the output', () => {
         const synopses = `.BROADCAST STUDIO - AFTERNOON
 
-                    = The Inciting Incident -- Jacorey and Arthur must save the studio during a power outage.`;
-        
+                    =The Inciting Incident -- Jacorey and Arthur must save the studio during a power outage.`;
+
         const sectionAndSynopses = `# ACT I
 
             = Set up the characters and the story.
@@ -694,9 +655,8 @@ describe('Inline markdown lexer', () => {
 
     it('should parse inline markdown', () => {
         const inlineText = '_***bold italics underline***_ _**bold underline**_ _*italic underline*_ ***bold italics*** **bold** *italics* _underline_';
-        let output: Script = fountain.parse(inlineText);
 
-        let actual = output.html.script;
+        let actual = fountain.parse(inlineText).html.script;
         let expected = '<p><span class="bold italic underline">bold italics underline</span> <span class="bold underline">bold underline</span> <span class="italic underline">italic underline</span> <span class="bold italic">bold italics</span> <span class="bold">bold</span> <span class="italic">italics</span> <span class="underline">underline</span></p>';
 
         expect(actual).toBe(expected);
@@ -772,9 +732,8 @@ describe('Inline markdown lexer', () => {
                             _*** bold italics underline***_ _***bold italics underline ***_
                             _** bold underline**_ _**bold underline **_
                             _* italic underline*_ _*italic underline *_`;
-        let output: Script = fountain.parse(inlineText);
 
-        let actual = output.html.script;
+        let actual = fountain.parse(inlineText).html.script;
         let expected = '<p>_ underline_ _underline _ * italic* *italic *<br />'
                        + '** bold** **bold **<br />'
                        + '*** bold italics*** ***bold italics ***<br />'
@@ -862,9 +821,7 @@ describe('Inline markdown lexer', () => {
                         grab your hats … because just then, a _BELL COBRA
                         HELICOPTER_ crests the edge of the bluff.`;
 
-        let output: Script = fountain.parse(action);
-
-        let actual = output.html.script;
+        let actual = fountain.parse(action).html.script;
         let expected = '<p>Murtaugh, springing hell bent for leather -- and folks,<br />grab your hats … because just then, a _BELL COBRA<br />HELICOPTER_ crests the edge of the bluff.</p>'
 
         expect(actual).toBe(expected);
@@ -894,8 +851,7 @@ describe('Additional compatibility tests', () => {
                         grab your hats … because just then, a BELL COBRA
                         HELICOPTER crests the edge of the bluff.`;
 
-        let output: Script = fountain.parse(action, true);
-
+        let output = fountain.parse(action, true);
         let expectedTokens = [
             new ActionToken(
                 'Murtaugh, *springing*, hell bent for leather -- and folks,\n'
@@ -911,7 +867,7 @@ describe('Additional compatibility tests', () => {
     });
 
     it('should return tokens via `getTokens` and its property', () => {
-        let output: Script = fountain.parse(
+        let output = fountain.parse(
             'They drink long and well from the beers.',
             true
         );
@@ -923,5 +879,9 @@ describe('Additional compatibility tests', () => {
 
         output = fountain.parse(scene, true);
         expect(output.tokens).toEqual(fountain.tokens);
+
+        // return tokens even if `getTokens` is false
+        output = fountain.parse('They drink long and well from the beers.');
+        expect(fountain.tokens).toBeDefined();
     });
 });

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -218,7 +218,7 @@ describe('Fountain Markup Parser', () => {
                     Dude, I'm a monkey.`;
 
         let actual = fountain.parse(dialog).html.script;
-        let expected = `<div class="dialogue"><h4>DEALER</h4><p>Ten.<br />Four.<br />Dealer gets a seven.<br />  <br />Hit or stand sir?</p></div><div class="dialogue"><h4>MONKEY</h4><p>Dude, I'm a monkey.</p></div>`;
+        let expected = `<div class="dialogue"><h4>DEALER</h4><p>Ten.<br />Four.<br />Dealer gets a seven.<br /><br />Hit or stand sir?</p></div><div class="dialogue"><h4>MONKEY</h4><p>Dude, I'm a monkey.</p></div>`;
 
         expect(actual).toBe(expected);
     });
@@ -389,7 +389,7 @@ describe('Fountain Markup Parser', () => {
         let actual = fountain.parse(singing).html.script;
         let expected = '<div class="dialogue"><h4>TREVA</h4><p class="parenthetical">(sing-song)</p><p class="lyrics">Oh my --<br />La~de~da!</p></div>';
 
-        expect(expected).toBe(actual);
+        expect(actual).toBe(expected);
     });
 
     it('should parse notes', () => {

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -30,6 +30,30 @@ describe('Fountain Markup Parser', () => {
         expect(actual).toEqual(expected);
     });
 
+    it('should handle empty strings gracefully', () => {
+        const empty = '';
+        const one_empty_line = '    ';
+        const empty_lines = '    \n    ';
+        const many_empty_lines = `
+    
+    
+        `;
+
+        let actual = fountain.parse(empty).html.script;
+        let expected = '';
+
+        expect(actual).toBe(expected);
+
+        actual = fountain.parse(one_empty_line).html.script;
+        expect(actual).toBe(expected);
+
+        actual = fountain.parse(empty_lines).html.script;
+        expect(actual).toBe(expected);
+
+        actual = fountain.parse(many_empty_lines).html.script;
+        expect(actual).toBe(expected);
+    });
+
     it('should parse forced action', () => {
         const action = '!William enters -- and there stands Anna.';
 

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -135,6 +135,10 @@ describe('Fountain Markup Parser', () => {
         expect(alphaNumToken).toEqual([ 
             new SceneHeadingToken('INT/EXT. HOUSE - DAY - FLASHBACK (1944) #110.A#')
         ]);
+
+        let actual = fountain.parse(alphaNumHeading).html.script;
+        let expected = '<h3 id="110.A">INT/EXT. HOUSE - DAY - FLASHBACK (1944)</h3>';
+        expect(actual).toBe(expected);
     });
 
     it('should parse forced, single-aplhanumeric scene headings', () => {

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -407,6 +407,7 @@ describe('Fountain Markup Parser', () => {
 
         let output: Script = fountain.parse(extremeEmphasis);
         let actual = output.html.script;
+
         let expected = `<div class="dialogue"><h4>TOPHER</h4><p class="parenthetical"><span class="italic">(griping)</span></p><p class="parenthetical"><span class="bold">(complaining)</span></p><p class="parenthetical"><span class="underline">(grousing)</span></p><p class="parenthetical"><span class="bold italic">(howling)</span></p><p class="parenthetical"><span class="italic underline">(screaming)</span></p><p class="parenthetical"><span class="bold underline">(clangorously)</span></p><p class="parenthetical"><span class="bold italic underline">(ear-splitting noises)</span></p><p>I'm upset.</p></div>`;
 
         expect(actual).toBe(expected);
@@ -432,7 +433,7 @@ describe('Fountain Markup Parser', () => {
         let output: Script = fountain.parse(notes);
         let actual = output.html.script;
 
-        const expected = '<!-- Add an additional beat here -->';
+        let expected = '<!-- Add an additional beat here -->';
 
         expect(actual).toBe(expected);
     });
@@ -444,8 +445,58 @@ describe('Fountain Markup Parser', () => {
         let output: Script = fountain.parse(lyrics);
         let actual = output.html.script;
 
-        const expected = '<p class="lyrics">Willy Wonka! Willy Wonka! The amazing chocolatier!<br />Willy Wonka! Willy Wonka! Everybody give a cheer!</p>';
+        let expected = '<p class="lyrics">Willy Wonka! Willy Wonka! The amazing chocolatier!<br />Willy Wonka! Willy Wonka! Everybody give a cheer!</p>';
 
+        expect(actual).toBe(expected);
+    });
+
+    it('should parse sections by removing them from the output', () => {
+        const section = `CUT TO:
+
+        # This is a Section
+
+        INT. PALACE HALLWAY - NIGHT`;
+
+        const manySections = `# Act
+
+        ## Sequence
+
+        ### Scene
+
+        ## Another Sequence
+
+        # Another Act`;
+
+        let actual = fountain.parse(section).html.script;
+        let expected = '<h2>CUT TO:</h2><h3>INT. PALACE HALLWAY - NIGHT</h3>';
+        expect(actual).toBe(expected);
+
+        actual = fountain.parse(manySections).html.script;
+        expected = '';
+        expect(actual).toBe(expected);
+    });
+
+    it('should parse synopses by removing them from the output', () => {
+        const synopses = `.BROADCAST STUDIO - AFTERNOON
+
+                    = The Inciting Incident -- Jacorey and Arthur must save the studio during a power outage.`;
+        
+        const sectionAndSynopses = `# ACT I
+
+            = Set up the characters and the story.
+
+            EXT. BRICK'S PATIO - DAY
+
+            = This scene sets up Brick & Steel's new life as retirees. Warm sun, cold beer, and absolutely nothing to do.
+
+            A gorgeous day. The sun is shining. But BRICK BRADDOCK, retired police detective, is sitting quietly, contemplating -- something.`;
+
+        let actual = fountain.parse(synopses).html.script;
+        let expected = '<h3>BROADCAST STUDIO - AFTERNOON</h3>';
+        expect(actual).toBe(expected);
+
+        actual = fountain.parse(sectionAndSynopses).html.script;
+        expected = "<h3>EXT. BRICK'S PATIO - DAY</h3><p>A gorgeous day. The sun is shining. But BRICK BRADDOCK, retired police detective, is sitting quietly, contemplating -- something.</p>";
         expect(actual).toBe(expected);
     });
 });

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -68,7 +68,7 @@ export class Fountain {
         let lexedText = '';
 
         if (token?.text) {
-            lexedText = this.inlineLex.reconstruct(token.text);
+            lexedText = this.inlineLex.reconstruct(token.text, token.type === 'action');
         }
 
         switch (token.type) {

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -88,8 +88,8 @@ export class Fountain {
             case 'dialogue_end': return `</div>`;
             case 'dual_dialogue_end': return `</div>`;
 
-            case 'section': return `<p class="section" data-depth="${token.depth}">${lexedText}</p>`;
-            case 'synopsis': return `<p class="synopsis">${lexedText}</p>`;
+            case 'section': return;
+            case 'synopsis': return;
 
             case 'note': return `<!-- ${lexedText} -->`;
             case 'boneyard_begin': return `<!-- `;

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -2,7 +2,6 @@ import { Token } from './token';
 
 import { Scanner } from './scanner';
 import { InlineLexer } from './lexer';
-
 import { unEscapeHTML } from './utilities';
 
 export interface Script {
@@ -37,7 +36,6 @@ export class Fountain {
             let title: string;
 
             this.tokens = this.scanner.tokenize(script);
-            const tokenCopy = JSON.parse(JSON.stringify(this.tokens)) as Token[];
 
             const titleToken = this.tokens.find(token => token.type === 'title');
             if (titleToken) {
@@ -52,8 +50,8 @@ export class Fountain {
             return {
                 title,
                 html: {
-                    title_page: tokenCopy.filter(token => token.is_title).map(token => this.to_html(token)).join(''),
-                    script: tokenCopy.filter(token => !token.is_title).map(token => this.to_html(token)).join('')
+                    title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''),
+                    script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('')
                 },
                 tokens: getTokens ? this.tokens : undefined
             }
@@ -65,45 +63,45 @@ export class Fountain {
     }
 
     to_html(token: Token) {
-        token.text = this.inlineLex.reconstruct(token.text);
+        let lexedText = this.inlineLex.reconstruct(token.text);
 
         switch (token.type) {
-            case 'title': return '<h1>' + token.text + '</h1>';
-            case 'credit': return '<p class="credit">' + token.text + '</p>';
-            case 'author': return '<p class="authors">' + token.text + '</p>';
-            case 'authors': return '<p class="authors">' + token.text + '</p>';
-            case 'source': return '<p class="source">' + token.text + '</p>';
-            case 'notes': return '<p class="notes">' + token.text + '</p>';
-            case 'draft_date': return '<p class="draft-date">' + token.text + '</p>';
-            case 'date': return '<p class="date">' + token.text + '</p>';
-            case 'contact': return '<p class="contact">' + token.text + '</p>';
-            case 'copyright': return '<p class="copyright">' + token.text + '</p>';
+            case 'title': return `<h1>${lexedText}</h1>`;
+            case 'credit': return `<p class="credit">${lexedText}</p>`;
+            case 'author': return `<p class="authors">${lexedText}</p>`;
+            case 'authors': return `<p class="authors">${lexedText}</p>`;
+            case 'source': return `<p class="source">${lexedText}</p>`;
+            case 'notes': return `<p class="notes">${lexedText}</p>`;
+            case 'draft_date': return `<p class="draft-date">${lexedText}</p>`;
+            case 'date': return `<p class="date">${lexedText}</p>`;
+            case 'contact': return `<p class="contact">${lexedText}</p>`;
+            case 'copyright': return `<p class="copyright">${lexedText}</p>`;
 
-            case 'scene_heading': return '<h3' + (token.scene_number ? ' id="' + token.scene_number + '">' : '>') + token.text + '</h3>';
-            case 'transition': return '<h2>' + token.text + '</h2>';
+            case 'scene_heading': return `<h3${(token.scene_number ? ` id="${token.scene_number}">` : `>`) + lexedText}</h3>`;
+            case 'transition': return `<h2>${lexedText}</h2>`;
 
-            case 'dual_dialogue_begin': return '<div class="dual-dialogue">';
-            case 'dialogue_begin': return '<div class="dialogue' + (token.dual ? ' ' + token.dual : '') + '">';
-            case 'character': return '<h4>' + token.text + '</h4>';
-            case 'parenthetical': return '<p class="parenthetical">' + token.text + '</p>';
-            case 'dialogue': return '<p>' + token.text + '</p>';
-            case 'dialogue_end': return '</div>';
-            case 'dual_dialogue_end': return '</div>';
+            case 'dual_dialogue_begin': return `<div class="dual-dialogue">`;
+            case 'dialogue_begin': return `<div class="dialogue${token.dual ? ' ' + token.dual : ''}">`;
+            case 'character': return `<h4>${lexedText}</h4>`;
+            case 'parenthetical': return `<p class="parenthetical">${lexedText}</p>`;
+            case 'dialogue': return `<p>${lexedText}</p>`;
+            case 'dialogue_end': return `</div>`;
+            case 'dual_dialogue_end': return `</div>`;
 
-            case 'section': return '<p class="section" data-depth="' + token.depth + '">' + token.text + '</p>';
-            case 'synopsis': return '<p class="synopsis">' + token.text + '</p>';
+            case 'section': return `<p class="section" data-depth="${token.depth}">${lexedText}</p>`;
+            case 'synopsis': return `<p class="synopsis">${lexedText}</p>`;
 
-            case 'note': return '<!-- ' + token.text + ' -->';
-            case 'boneyard_begin': return '<!-- ';
-            case 'boneyard_end': return ' -->';
+            case 'note': return `<!-- ${lexedText} -->`;
+            case 'boneyard_begin': return `<!-- `;
+            case 'boneyard_end': return ` -->`;
 
-            case 'action': return '<p>' + token.text + '</p>';
-            case 'centered': return '<p class="centered">' + token.text + '</p>';
+            case 'action': return `<p>${lexedText}</p>`;
+            case 'centered': return `<p class="centered">${lexedText}</p>`;
 
-            case 'lyrics': return '<p class="lyrics">' + token.text + '</p>';
+            case 'lyrics': return `<p class="lyrics">${lexedText}</p>`;
 
-            case 'page_break': return '<hr />';
-            case 'line_break': return '<br />';
+            case 'page_break': return `<hr />`;
+            case 'line_break': return `<br />`;
         }
     }
 }

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -65,7 +65,7 @@ export class Fountain {
     }
 
     to_html(token: Token) {
-        let lexedText: string | undefined;
+        let lexedText = '';
 
         if (token?.text) {
             lexedText = this.inlineLex.reconstruct(token.text);
@@ -107,7 +107,7 @@ export class Fountain {
             case 'lyrics': return `<p class="lyrics">${lexedText}</p>`;
 
             case 'page_break': return `<hr />`;
-            case 'line_break': return `<br />`;
+            case 'spaces': return;
         }
     }
 }

--- a/src/fountain.ts
+++ b/src/fountain.ts
@@ -5,12 +5,12 @@ import { InlineLexer } from './lexer';
 import { unEscapeHTML } from './utilities';
 
 export interface Script {
-    title?: string,
+    title: string,
     html: {
         title_page: string,
         script: string
     },
-    tokens?: Token[]
+    tokens: Token[]
 }
 
 export class Fountain {
@@ -33,12 +33,12 @@ export class Fountain {
             );
 
         try {
-            let title: string;
+            let title: string = '';
 
             this.tokens = this.scanner.tokenize(script);
 
             const titleToken = this.tokens.find(token => token.type === 'title');
-            if (titleToken) {
+            if (titleToken?.text) {
                 // lexes any inlines on the title then removes any HTML / line breaks
                 title = unEscapeHTML(
                             this.inlineLex.reconstruct(titleToken.text)
@@ -50,10 +50,12 @@ export class Fountain {
             return {
                 title,
                 html: {
-                    title_page: this.tokens.filter(token => token.is_title).map(token => this.to_html(token)).join(''),
-                    script: this.tokens.filter(token => !token.is_title).map(token => this.to_html(token)).join('')
+                    title_page: this.tokens.filter(token => token.is_title)
+                                    .map(token => this.to_html(token)).join(''),
+                    script: this.tokens.filter(token => !token.is_title)
+                                    .map(token => this.to_html(token)).join('')
                 },
-                tokens: getTokens ? this.tokens : undefined
+                tokens: getTokens ? this.tokens : []
             }
         } catch (error) {
             error.message +=
@@ -63,7 +65,11 @@ export class Fountain {
     }
 
     to_html(token: Token) {
-        let lexedText = this.inlineLex.reconstruct(token.text);
+        let lexedText: string | undefined;
+
+        if (token?.text) {
+            lexedText = this.inlineLex.reconstruct(token.text);
+        }
 
         switch (token.type) {
             case 'title': return `<h1>${lexedText}</h1>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './fountain';
 export { Token } from './token';
 export { FountainTypes, rules } from './rules';
-export { Lexer, InlineTypes, InlineLexer } from './lexer';
+export { InlineTypes, InlineLexer } from './lexer';

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -24,14 +24,28 @@ export class InlineLexer {
         escape: '$1'
     };
 
-    reconstruct(line: string) {
-        const styles = ['bold_italic_underline', 'bold_underline', 'italic_underline', 'bold_italic', 'bold', 'italic', 'underline'];
+    reconstruct(line: string, escapeSpaces = false) {
+        const styles = [
+            'bold_italic_underline',
+            'bold_underline',
+            'italic_underline',
+            'bold_italic',
+            'bold',
+            'italic',
+            'underline'
+        ];
 
         line = escapeHTML(
                 line
                     .replace(rules.note_inline, this.inline.note)
                     .replace(rules.escape, '[{{{$&}}}]')                    // perserve escaped characters
         );
+
+        if (escapeSpaces) {
+            line = line.replace(/^( +)/gm, (_, spaces) => {
+                return '&nbsp;'.repeat(spaces.length);
+            });
+        }
 
         for (let style of styles) {
             const rule: RegExp = rules[style];
@@ -44,6 +58,6 @@ export class InlineLexer {
         return line
                 .replace(/\n/g, this.inline.line_break)
                 .replace(/\[{{{\\(&.+?;|.)}}}]/g, this.inline.escape)       // restore escaped chars to intended sequence
-                .trim();
+                .trimEnd();
     }
 }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -7,16 +7,7 @@ export type InlineTypes = 'note' | 'line_break'
                 | 'bold' | 'italic'
                 | 'underline' | 'escape';
 
-export class Lexer {
-    reconstruct(script: string) {
-        return script.replace(rules.boneyard, '\n$1\n')
-            .replace(rules.standardizer, '\n')
-            .replace(rules.cleaner, '')
-            .replace(rules.whitespacer, '');
-    }
-}
-
-export class InlineLexer extends Lexer {
+export class InlineLexer {
     inline: Record<InlineTypes, string> = {
         note: '<!-- $1 -->',
 

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -34,10 +34,6 @@ export class InlineLexer extends Lexer {
     };
 
     reconstruct(line: string) {
-        if (!line) 
-            return;
-
-        let match: RegExp;
         const styles = ['bold_italic_underline', 'bold_underline', 'italic_underline', 'bold_italic', 'bold', 'italic', 'underline'];
 
         line = escapeHTML(
@@ -47,16 +43,16 @@ export class InlineLexer extends Lexer {
         );
 
         for (let style of styles) {
-            match = rules[style];
+            const rule: RegExp = rules[style];
 
-            if (match.test(line)) {
-                line = line.replace(match, this.inline[style]);
+            if (rule.test(line)) {
+                line = line.replace(rule, this.inline[style]);
             }
         }
 
         return line
                 .replace(/\n/g, this.inline.line_break)
-                .replace(/\[{{{\\(&.+?;|.)}}}]/g, this.inline.escape)         // restore escaped chars to intended sequence
+                .replace(/\[{{{\\(&.+?;|.)}}}]/g, this.inline.escape)       // restore escaped chars to intended sequence
                 .trim();
     }
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -30,7 +30,7 @@ export const rules: Record<FountainTypes, RegExp> = {
     lyrics: /^~(?! ).+(?:\n~(?! ).+)*/,
 
     section: /^(#+) *(.*)/,
-    synopsis: /^(?:\=(?!\=+) *)(.*)/,
+    synopsis: /^=(?!=+) *(.*)/,
 
     note: /^\[{2}(?!\[+)(.+)]{2}(?!\[+)$/,
     note_inline: /\[{2}(?!\[+)([\s\S]+?)]{2}(?!\[+)/g,

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -10,8 +10,7 @@ export type FountainTypes = 'title_page' | 'scene_heading'
                 | 'italic_underline' | 'bold_italic'
                 | 'bold' | 'italic'
                 | 'underline' | 'escape'
-                | 'splitter' | 'cleaner'
-                | 'standardizer' | 'whitespacer';
+                | 'blank_line' | 'end_of_lines';
 
 export const rules: Record<FountainTypes, RegExp> = {
     title_page: /^((?:title|credit|authors?|source|notes|draft date|date|contact|copyright)\:)/gim,
@@ -50,8 +49,6 @@ export const rules: Record<FountainTypes, RegExp> = {
 
     escape: /\\([@#!*_$~`+=.><\\\/])/g,
 
-    splitter: /\n{2,}/g,
-    cleaner: /^\n+|\n+$/,
-    standardizer: /\r\n|\r/g,
-    whitespacer: /^\t+|^ {3,}/gm
+    blank_line: /^(?: *(?:\n|$))+/,
+    end_of_lines: /(?:\n|$){2,}/g
 };

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -13,23 +13,23 @@ export type FountainTypes = 'title_page' | 'scene_heading'
                 | 'blank_line' | 'end_of_lines';
 
 export const rules: Record<FountainTypes, RegExp> = {
-    title_page: /^((?:title|credit|authors?|source|notes|draft date|date|contact|copyright)\:)/gim,
+    title_page: /^\s*((?:title|credit|authors?|source|notes|draft date|date|contact|copyright)\:)/gim,
 
-    scene_heading: /^((?:\*{0,3}_?)?(?:(?:int|i)\.?\/(?:ext|e)|int|ext|est)[. ].+)|^\.(?!\.+)(\S.*)/i,
+    scene_heading: /^\s*((?:\*{0,3}_?)?(?:(?:int|i)\.?\/(?:ext|e)|int|ext|est)[. ].+)|^\s*\.(?!\.+)(\S.*)/i,
     scene_number: /( *#(.+)# *)/,
 
-    transition: /^((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:)|^> *(.+)/,
+    transition: /^\s*((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:)\s*$|^\s*> *(.+)$/,
 
-    dialogue: /(?!^[0-9 _*]+(?:\(.*\))?[ *_]*(?:\^?)?\s*\n)(^(?:(?!\\?@|!)[^^()\na-z]+|@[^^()\n]+)(?: *\(.*\))?[ *_]*)(\^?)?\s*\n(?!\n+)([\s\S]+)/,
+    dialogue: /(?!^\s*\\@|^\s*!)(?!^\s*[0-9 _*]+(?:\(.*\))?[*_]*(?:\^?)?\s*\n)(^\s*(?:@[^^()\n]+|[^^()\na-z]+)(?: *\(.*\))?[ *_]*)(\^?)?\s*\n(?!\n+)([\s\S]+)/,
     parenthetical: /^ *(?:(?<u1>_{0,1})(?<s1>\*{0,3})(?=.+\k<s1>\k<u1>)|(?<s2>\*{0,3})(?<u2>_{0,1})(?=.+\k<u2>\k<s2>))(\(.+?\))(\k<s1>\k<u1>|\k<u2>\k<s2>) *$/,
 
     action: /^(.+)/g,
-    centered: /^> *(.+) *<(\n.+)*/g,
+    centered: /^\s*>.+<[^\S\r\n]*(?:\s*>.+<[^\S\r\n]*)*/g,
 
-    lyrics: /^~(?! ).+(?:\n~(?! ).+)*/,
+    lyrics: /^\s*~(?! ).+(?:\n\s*~(?! ).+)*/,
 
-    section: /^(#+) *(.*)/,
-    synopsis: /^=(?!=+) *(.*)/,
+    section: /^\s*(#+) *(.*)/,
+    synopsis: /^\s*=(?!=+) *(.*)/,
 
     note: /^\[{2}(?!\[+)(.+)]{2}(?!\[+)$/,
     note_inline: /\[{2}(?!\[+)([\s\S]+?)]{2}(?!\[+)/g,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -4,7 +4,6 @@ import {
     BoneyardToken,
     CenteredToken,
     DialogueBlock,
-    LineBreakToken,
     LyricsToken,
     NoteToken,
     PageBreakToken,
@@ -71,10 +70,6 @@ export class Scanner {
             /** page breaks */
             if (PageBreakToken.matchedBy(line)) {
                 return new PageBreakToken().addTo(previous);
-            }
-            /** line breaks */
-            if (LineBreakToken.matchedBy(line)) {
-                return new LineBreakToken().addTo(previous);
             }
             // everything else is action -- remove `!` for forced action
             return new ActionToken(line).addTo(previous);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -9,6 +9,7 @@ import {
     PageBreakToken,
     SceneHeadingToken,
     SectionToken,
+    SpacesToken,
     SynopsisToken,
     TitlePageBlock,
     Token,
@@ -24,10 +25,14 @@ export class Scanner {
                             .replace(rules.boneyard, '\n$1\n')
                             .replace(/\r\n|\r/g, '\n')                      // convert carriage return / returns to newline
                             .replace(/^\t+|^ {3,}/gm, '')                   // remove tabs / 3+ whitespaces
-                            .split(rules.splitter)
+                            .split(rules.end_of_lines)
                             .reverse();
 
         const tokens: Token[] = source.reduce((previous: Token[], line: string) => {
+            /** spaces */
+            if (SpacesToken.matchedBy(line)) {
+                return new SpacesToken().addTo(previous);
+            }
             /** title page */
             if (TitlePageBlock.matchedBy(line)) {
                 return new TitlePageBlock(line).addTo(previous);

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -24,7 +24,6 @@ export class Scanner {
         const source: string[] = script
                             .replace(rules.boneyard, '\n$1\n')
                             .replace(/\r\n|\r/g, '\n')                      // convert carriage return / returns to newline
-                            .replace(/^\t+|^ {3,}/gm, '')                   // remove tabs / 3+ whitespaces
                             .split(rules.end_of_lines)
                             .reverse();
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -14,7 +14,7 @@ import {
     TitlePageBlock,
     Token,
     TransitionToken
- } from './token';
+} from './token';
 
 import { Lexer } from './lexer';
 
@@ -78,8 +78,8 @@ export class Scanner {
             }
             // everything else is action -- remove `!` for forced action
             return new ActionToken(line).addTo(previous);
-        }, [])
-        
+        }, []);
+
         return tokens.reverse();
     }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -47,7 +47,7 @@ export class TitlePageToken implements Token {
     constructor(item: string) {
         const pair = item.split(/\:\n*/);
         this.type = pair[0].trim().toLowerCase().replace(' ', '_');
-        this.text = pair[1].trim();
+        this.text = pair[1].replace(/^\s*/gm, '');
     }
 
     addTo(tokens: Token[]): Token[] {
@@ -89,7 +89,7 @@ export class CenteredToken implements Token {
     constructor(line: string) {
         const match = line.match(rules.centered);
         if (match) {
-            this.text = match[0].replace(/ *[><] */g, '');
+            this.text = match[0].replace(/[^\S\n]*[><][^\S\n]*/g, '');
         }
     }
 
@@ -131,7 +131,7 @@ export class DialogueBlock implements Block {
         const match = line.match(rules.dialogue);
 
         if (match) {
-            let name = match[1];
+            let name = match[1].trim();
 
             // iterating from the bottom up, so push dialogue blocks in reverse order
             const isDualDialogue = !!match[2];
@@ -152,6 +152,8 @@ export class DialogueBlock implements Block {
                 if (rules.line_break.test(text)) {
                     text = '';
                 }
+                text = text.trim();
+
                 if (rules.parenthetical.test(text)) {
                     return [...p, new ParentheticalToken(text)];
                 }
@@ -280,7 +282,7 @@ export class LyricsToken implements Token {
     readonly text: string;
 
     constructor(line: string) {
-        this.text = line.replace(/^~(?! )/gm, '');
+        this.text = line.replace(/^\s*~(?! )/gm, '');
     }
 
     addTo(tokens: Token[]): Token[] {
@@ -403,7 +405,10 @@ export class ActionToken implements Token {
     readonly text: string;
 
     constructor(line: string) {
-        this.text = line.replace(/^!(?! )/gm, '');
+        this.text = line.replace(/^(\s*)!(?! )/gm, '$1')
+                .replace(/^( *)(\t+)/gm, (_, leading, tabs) => {
+                    return leading + '    '.repeat(tabs.length);
+                });
     }
 
     addTo(tokens: Token[]): Token[] {

--- a/src/token.ts
+++ b/src/token.ts
@@ -146,6 +146,9 @@ export class DialogueBlock implements Block {
                 if (!text.length) {
                     return p;
                 }
+                if (rules.line_break.test(text)) {
+                    text = '';
+                }
                 if (rules.parenthetical.test(text)) {
                     return [...p, new ParentheticalToken(text)];
                 }
@@ -158,11 +161,9 @@ export class DialogueBlock implements Block {
                         return [...p, new LyricsToken(text)];
                     }
                 }
-                if (previousToken) {
-                    if (previousToken.type === 'dialogue') {
-                        p[lastIndex].text = `${previousToken.text}\n${text}`;
-                        return p;
-                    }
+                if (previousToken?.type === 'dialogue') {
+                    p[lastIndex].text = `${previousToken.text}\n${text}`;
+                    return p;
                 }
                 return [...p, new DialogueToken(text)];
             }, [] as Token[]).reverse();
@@ -381,20 +382,6 @@ export class PageBreakToken implements Token {
         return rules.page_break.test(line);
     }
 }
-
-
-export class LineBreakToken implements Token {
-    readonly type = 'line_break';
-
-    addTo(tokens: Token[]): Token[] {
-        return [...tokens, this];
-    }
-
-    static matchedBy(line: string) {
-        return rules.line_break.test(line);
-    }
-}
-
 
 export class ActionToken implements Token {
     readonly type = 'action';

--- a/src/token.ts
+++ b/src/token.ts
@@ -21,7 +21,10 @@ export class TitlePageBlock implements Block {
     readonly tokens: Token[] = [];
 
     constructor(line: string) {
-        const match = line.replace(rules.title_page, '\n$1').split(rules.splitter).reverse();
+        const match = line
+                    .replace(rules.title_page, '\n$1')
+                    .split(rules.end_of_lines)
+                    .reverse();
         this.tokens = match.reduce(
             (previous, item) => new TitlePageToken(item).addTo(previous)
         , []);
@@ -42,7 +45,7 @@ export class TitlePageToken implements Token {
     readonly text: string;
 
     constructor(item: string) {
-        const pair = item.replace(rules.cleaner, '').split(/\:\n*/);
+        const pair = item.split(/\:\n*/);
         this.type = pair[0].trim().toLowerCase().replace(' ', '_');
         this.text = pair[1].trim();
     }
@@ -380,6 +383,18 @@ export class PageBreakToken implements Token {
 
     static matchedBy(line: string) {
         return rules.page_break.test(line);
+    }
+}
+
+export class SpacesToken implements Token {
+    readonly type = 'spaces';
+
+    addTo(tokens: Token[]): Token[] {
+        return [...tokens, this];
+    }
+
+    static matchedBy(line: string) {
+        return rules.blank_line.test(line);
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "moduleResolution": "node",
     "outDir": "dist",
-    "sourceMap": true
+    "sourceMap": true,
+    "strictNullChecks": true
   },
   "include": [
     "./src/**/*.ts"


### PR DESCRIPTION
## [1.2.0] - 2023-10-27

### Added

- Tabs and spaces retained in Action elements. Tabs are converted to four spaces.

### Changed

- Improve rendering per spec like stripping sections and synopses since these should not be rendered.
- Return more explicit null values and enable strict null checking.
- Better whitespace handling while lexing.

### Fixed

- Fix line break logic in dialogue.
- Fix issue with empty strings returning `<p>undefined</p>`.