### PR TITLE
Fix Commenting, Change Boneyard Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,18 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Add line numbers to tokens.
 - Allow any title field attributes.
 - Better title page parsing in general.
-- Fix boneyard and notes parsing.
+- Boneyard is preserved as a token instead of stripped form input.
 - Work on options for perserving vertical space in Action per spec.
+
+## [1.2.1] - 2023-10-28
+
+### Changed
+
+- Boneyard is stripped from input before parsing for now. Intention is to make this a token with version two.
+
+### Fixed
+
+- HTML comments are no longer accidentally escaped within the `InlineLexer`.
 
 ## [1.2.0] - 2023-10-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountain-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A simple parser for Fountain, a markup language for formatting screenplays.",
   "main": "dist/index.js",
   "module": "dist.esm/index.js",

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -36,9 +36,7 @@ export class InlineLexer {
         ];
 
         line = escapeHTML(
-                line
-                    .replace(rules.note_inline, this.inline.note)
-                    .replace(rules.escape, '[{{{$&}}}]')                    // perserve escaped characters
+                line.replace(rules.escape, '[{{{$&}}}]')                    // perserve escaped characters
         );
 
         if (escapeSpaces) {
@@ -56,6 +54,7 @@ export class InlineLexer {
         }
 
         return line
+                .replace(rules.note_inline, this.inline.note)
                 .replace(/\n/g, this.inline.line_break)
                 .replace(/\[{{{\\(&.+?;|.)}}}]/g, this.inline.escape)       // restore escaped chars to intended sequence
                 .trimEnd();

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -33,7 +33,7 @@ export const rules: Record<FountainTypes, RegExp> = {
 
     note: /^\[{2}(?!\[+)(.+)]{2}(?!\[+)$/,
     note_inline: /\[{2}(?!\[+)([\s\S]+?)]{2}(?!\[+)/g,
-    boneyard: /(^\/\*|^\*\/)$/g,
+    boneyard: /\/\*[\S\s]*?\*\//g,
 
     page_break: /^={3,}$/,
     line_break: /^ {2}$/,

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,7 +1,6 @@
 import { rules } from './rules';
 import { 
     ActionToken,
-    BoneyardToken,
     CenteredToken,
     DialogueBlock,
     LyricsToken,
@@ -19,10 +18,20 @@ import {
 export class Scanner {
     private lastLineWasDualDialogue: boolean;
 
+    boneyardStripper(match: string) {
+        const endAtStrStart = /^[^\S\n]*\*\//m;
+        let boneyardEnd = '';
+
+        if (endAtStrStart.test(match)) {
+            boneyardEnd = '\n\n';
+        }
+        return boneyardEnd;
+    }
+
     tokenize(script: string): Token[] {
         // reverse the array so that dual dialog can be constructed bottom up
         const source: string[] = script
-                            .replace(rules.boneyard, '\n$1\n')
+                            .replace(rules.boneyard, this.boneyardStripper)
                             .replace(/\r\n|\r/g, '\n')                      // convert carriage return / returns to newline
                             .split(rules.end_of_lines)
                             .reverse();
@@ -65,10 +74,6 @@ export class Scanner {
             /** notes */
             if (NoteToken.matchedBy(line)) {
                 return new NoteToken(line).addTo(previous);
-            }
-            /** boneyard */
-            if (BoneyardToken.matchedBy(line)) {
-                return new BoneyardToken(line).addTo(previous);
             }
             /** lyrics */
             if (LyricsToken.matchedBy(line)) {

--- a/src/token.ts
+++ b/src/token.ts
@@ -356,26 +356,6 @@ export class NoteToken implements Token {
     }
 }
 
-export class BoneyardToken implements Token {
-    readonly type: 'boneyard_begin' | 'boneyard_end';
-    readonly text: string;
-
-    constructor(line: string) {
-        const match = line.match(rules.boneyard);
-        if (match) {
-            this.type = match[0][0] === '/' ? 'boneyard_begin' : 'boneyard_end';
-        }
-    }
-
-    addTo(tokens: Token[]): Token[] {
-        return [...tokens, this];
-    }
-
-    static matchedBy(line: string) {
-        return rules.boneyard.test(line);
-    }
-}
-
 export class PageBreakToken implements Token {
     readonly type = 'page_break';
 


### PR DESCRIPTION
## [1.2.1] - 2023-10-28

### Changed

- Boneyard is stripped from input before parsing for now. Intention is to make this a token with version two.

### Fixed

- HTML comments are no longer accidentally escaped within the `InlineLexer`.