### PR TITLE
Allow additoinal Title Page fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-- Add line numbers to tokens.
-- Allow any title field attributes.
-- Better title page parsing in general.
+- Add line numbers and/or paragraph numbers to tokens.
 - Boneyard is preserved as a token instead of stripped form input.
 - Work on options for perserving vertical space in Action per spec.
+
+## [1.2.2] - 2023-10-28
+
+### Added
+
+- Allow any title field attributes that are found _underneath_ one of the following recommended attributes: `Title`, `Credit`, `Author/s`, `Source`, `Notes`, `Draft date`, `Date`, `Contact`, or `Copyright`.
+
+### Fixed
+
+- Better title page parsing in general.
 
 ## [1.2.1] - 2023-10-28
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,7 @@ A simple parser for [Fountain](http://fountain.io/), a markup language for forma
 
 Special thanks to [Nathan Hoad](https://www.npmjs.com/~nathanhoad) for the Fountain-js package namespace.
 
-## Syntax Support
-
 Supports up to `v 1.1` of the [Fountain syntax](https://www.fountain.io/syntax#section-changes).
-
-Currently Fountain-js supports a limited range of key-value pairs for title pages -
-
-* `Title`, `Credit`, `Author/s`, `Source`, `Notes`, `Draft date`, `Date`, `Contact`, `Copyright`
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fountain-js",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A simple parser for Fountain, a markup language for formatting screenplays.",
   "main": "dist/index.js",
   "module": "dist.esm/index.js",

--- a/spec/fountain.spec.ts
+++ b/spec/fountain.spec.ts
@@ -97,6 +97,25 @@ describe('Fountain Markup Parser', () => {
         expect(actual).toEqual(expected);
     });
 
+    it('should ignore unrecognized title fields', () => {
+        const title_page = `Title:
+                            _**BRICK & STEEL**_
+                        Revision: Blue
+                        Type: Pilot`;
+
+        let actual: Script = fountain.parse(title_page);
+        let expected: Script = {
+            title: 'BRICK & STEEL',
+            html: {
+                title_page: '<h1><span class="bold underline">BRICK &amp; STEEL</span></h1>',
+                script: ''
+            },
+            tokens: []
+        };
+
+        expect(expected).toEqual(actual);
+    });
+
     it('should parse a scene heading', () => {
         const sceneHeading = "EXT. BRICK'S PATIO - DAY";
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -22,7 +22,7 @@ export class TitlePageBlock implements Block {
 
     constructor(line: string) {
         const match = line
-                    .replace(rules.title_page, '\n$1')
+                    .replace(/^([^\n]+:)/gm, '\n$1')
                     .split(rules.end_of_lines)
                     .reverse();
         this.tokens = match.reduce(
@@ -45,9 +45,9 @@ export class TitlePageToken implements Token {
     readonly text: string;
 
     constructor(item: string) {
-        const pair = item.split(/\:\n*/);
-        this.type = pair[0].trim().toLowerCase().replace(' ', '_');
-        this.text = pair[1].replace(/^\s*/gm, '');
+        const [key, value] = item.split(/\:\n*/, 2);
+        this.type = key.trim().toLowerCase().replace(/ /g, '_');
+        this.text = value.replace(/^\s*/gm, '');
     }
 
     addTo(tokens: Token[]): Token[] {


### PR DESCRIPTION
## [1.2.2] - 2023-10-28

### Added

- Allow any title field attributes that are found _underneath_ one of the following recommended attributes: `Title`, `Credit`, `Author/s`, `Source`, `Notes`, `Draft date`, `Date`, `Contact`, or `Copyright`.

### Fixed

- Better title page parsing in general.